### PR TITLE
rename TimedLock and TimedUnlock (which sound like the timer applies to

### DIFF
--- a/cloudmutex.go
+++ b/cloudmutex.go
@@ -17,7 +17,7 @@ type cloudmutex struct {
 	service *storage.Service
 }
 
-// Lock will wait up to duruation d for l.Lock() to succeed.
+// Lock waits up to duruation d for l.Lock() to succeed.
 func Lock(l sync.Locker, d time.Duration) error {
 	done := make(chan struct{}, 1)
 	go func() {
@@ -32,7 +32,7 @@ func Lock(l sync.Locker, d time.Duration) error {
 	}
 }
 
-// Unlock will wait up to duruation d for l.Unlock() to succeed.
+// Unlock waits up to duruation d for l.Unlock() to succeed.
 func Unlock(l sync.Locker, d time.Duration) error {
 	done := make(chan struct{}, 1)
 	go func() {
@@ -47,7 +47,7 @@ func Unlock(l sync.Locker, d time.Duration) error {
 	}
 }
 
-// The Lock method waits indefinitely to acquire a global mutex lock.
+// Lock waits indefinitely to acquire a global mutex lock.
 func (m cloudmutex) Lock() {
 	object := &storage.Object{Name: m.object}
 	for {
@@ -58,7 +58,7 @@ func (m cloudmutex) Lock() {
 	}
 }
 
-// The Unlock method waits indefinitely to relinquish a global mutex lock.
+// Unlock waits indefinitely to relinquish a global mutex lock.
 func (m cloudmutex) Unlock() {
 	for {
 		err := m.service.Objects.Delete(m.bucket, m.object).Do()

--- a/cloudmutex_test.go
+++ b/cloudmutex_test.go
@@ -13,26 +13,26 @@ const (
 )
 
 var (
-	limit        = 1
-	lock_held_by = -1
+	limit      = 1
+	lockHolder = -1
 )
 
 func locker(done chan struct{}, t *testing.T, i int, m sync.Locker) {
-	local_mutex := &sync.Mutex{}
+	var lockHolderMutex sync.Mutex
 	m.Lock()
-	local_mutex.Lock()
-	if lock_held_by != -1 {
+	lockHolderMutex.Lock()
+	if lockHolder != -1 {
 		t.Errorf("%d trying to lock, but already held by %d",
-			i, lock_held_by)
+			i, lockHolder)
 	}
-	lock_held_by = i
-	local_mutex.Unlock()
+	lockHolder = i
+	lockHolderMutex.Unlock()
 	t.Logf("locked by %d", i)
 	time.Sleep(10 * time.Millisecond)
 	m.Unlock()
-	local_mutex.Lock()
-	lock_held_by = -1
-	local_mutex.Unlock()
+	lockHolderMutex.Lock()
+	lockHolder = -1
+	lockHolderMutex.Unlock()
 	done <- struct{}{}
 }
 


### PR DESCRIPTION
holding rather than obtaining locks) to simple Lock and Unlock at the package level.
Also, clean up test code accordingly and add local mutexes to protect local access
to share data.
.
