### PR TITLE
add context.WithTimeout (to force termination of goroutine),

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The godoc document can be found [here](https://godoc.org/github.com/marcacohen/g
 1. In your Go code, import `github.com/marcacohen/gcslock` and use it as follows:
 
 ```go
-m, err := gcslock.New(nil, project, bucket, object)
+m, err := gcslock.New(nil, bucket, object)
 if err != nil {
   log.Fatal(err)
 }
@@ -119,7 +119,7 @@ use of locking/unlocking with a timeout context:
 
 ```go
 // Instantiate mutex and setup a context with 100ms timeout.
-m, err := gcslock.New(nil, project, bucket, object)
+m, err := gcslock.New(nil, bucket, object)
 if err != nil {
   log.Fatal(err)
 }

--- a/README.md
+++ b/README.md
@@ -110,22 +110,32 @@ The Lock() and Unlock() methods implemented by this package follow the same
 semantics as the standard [sync.Locker interface](https://golang.org/pkg/sync/#Locker):
 they block indefinitely waiting to acquire or relinquish a lock. But sometimes
 you can't afford to wait forever for something to happen. Of course, you can
-implement your own timeout logic but to make life easier for clients, this
-library offers a built-in version of Lock() and Unlock() package level functions
-which accept a timeout value, expressed as a `time.duration`. Here's an example
-use of each:
+implement your own timeout logic but to make life easier for clients, the mutex
+object also offers the ContextLock() and ContextUnlock() methods, which accept
+a context with an optional preset timeout value. If the context does not have
+an associated timeout then these calls are equivalent to the Lock/Unlock methods
+(i.e. they wait indefinitely to acquire/release the mutex). Here's an example 
+use of locking/unlocking with a timeout context:
 
 ```go
-// Wait up to 100ms to acquire a lock.
-if err := gcslock.Lock(m, 100*time.Millisecond); err != nil {
+// Instantiate mutex and setup a context with 100ms timeout.
+m, err := gcslock.New(nil, project, bucket, object)
+if err != nil {
   log.Fatal(err)
 }
+ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+defer cancel()
 
-// Do something interesting (and protected) here.
+// Wait up to 100ms to acquire a lock.
+if err = m.ContextLock(ctx); err != nil {
+	return err
+}
 
-// Wait up to 100ms to relinquish a lock.
-if err := gcslock.Unlock(m, 100*time.Millisecond); err != nil {
-  log.Fatal(err)
+// Do protected work here.
+
+// Wait up to 100ms to relinquish the lock.
+if err = m.ContextUnlock(ctx); err != nil {
+	return err
 }
 ```
 

--- a/mutex.go
+++ b/mutex.go
@@ -115,7 +115,6 @@ func (m *mutex) ContextUnlock(ctx context.Context) error {
 			// Likely malformed URL - retry won't fix so return.
 			return err
 		}
-		req.Header.Set("content-type", "text/plain")
 		req = req.WithContext(ctx)
 		res, err := m.client.Do(req)
 		if err == nil {

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -211,7 +211,6 @@ func TestLockShouldNotTimeout(t *testing.T) {
 func TestUnlockShouldTimeout(t *testing.T) {
 	// Google cloud storage stub that takes 10ms to respond.
 	storage := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("hi marc\n")
 		time.Sleep(10 * time.Millisecond)
 		w.WriteHeader(http.StatusNoContent)
 	}))

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // make sure mutex pointer satisfies sync.Locker
@@ -48,10 +50,10 @@ func TestLock(t *testing.T) {
 	}))
 	defer storage.Close()
 	storageLockURL = storage.URL
-
+	httpClient = func(context.Context) (*http.Client, error) { return http.DefaultClient, nil }
 	m, err := New(nil, "stub", "gcslock", "lock")
 	if err != nil {
-		t.Fatal("unable to allocate a gcslock.mutex object")
+		t.Fatal(err)
 	}
 	done := make(chan struct{})
 	go func() {
@@ -83,7 +85,7 @@ func TestLockRetry(t *testing.T) {
 
 	m, err := New(nil, "stub", "gcslock", "lock")
 	if err != nil {
-		t.Fatal("unable to allocate a gcslock.mutex object")
+		t.Fatal(err)
 	}
 	done := make(chan struct{})
 	go func() {
@@ -118,7 +120,7 @@ func TestUnlock(t *testing.T) {
 
 	m, err := New(nil, "stub", "gcslock", "lock")
 	if err != nil {
-		t.Fatal("unable to allocate a gcslock.mutex object")
+		t.Fatal(err)
 	}
 	done := make(chan struct{})
 	go func() {
@@ -152,7 +154,7 @@ func TestUnlockRetry(t *testing.T) {
 
 	m, err := New(nil, "stub", "gcslock", "lock")
 	if err != nil {
-		t.Fatal("unable to allocate a gcslock.mutex object")
+		t.Fatal(err)
 	}
 	done := make(chan struct{})
 	go func() {

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -54,7 +54,7 @@ func TestLock(t *testing.T) {
 	}))
 	defer storage.Close()
 	storageLockURL = storage.URL
-	m, err := New(nil, "stub", "gcslock", "lock")
+	m, err := New(nil, "gcslock", "lock")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func TestLockRetry(t *testing.T) {
 	defer storage.Close()
 	storageLockURL = storage.URL
 
-	m, err := New(nil, "stub", "gcslock", "lock")
+	m, err := New(nil, "gcslock", "lock")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestUnlock(t *testing.T) {
 	defer storage.Close()
 	storageUnlockURL = storage.URL
 
-	m, err := New(nil, "stub", "gcslock", "lock")
+	m, err := New(nil, "gcslock", "lock")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestUnlockRetry(t *testing.T) {
 	defer storage.Close()
 	storageUnlockURL = storage.URL
 
-	m, err := New(nil, "stub", "gcslock", "lock")
+	m, err := New(nil, "gcslock", "lock")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func (l *mockContextLocker) Unlock() {
 }
 
 func TestLockTimeout(t *testing.T) {
-	mut, err := New(nil, "stub", "gcslock", "lock")
+	mut, err := New(nil, "gcslock", "lock")
 	if err != nil {
 		t.Fatal("unable to allocate a gcslock.mutex object")
 	}
@@ -207,7 +207,7 @@ func TestLockTimeout(t *testing.T) {
 }
 
 func TestUnlockTimeout(t *testing.T) {
-	mut, err := New(nil, "stub", "gcslock", "lock")
+	mut, err := New(nil, "gcslock", "lock")
 	if err != nil {
 		t.Fatal("unable to allocate a gcslock.mutex object")
 	}

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -29,6 +29,10 @@ import (
 // make sure mutex pointer satisfies sync.Locker
 var _ sync.Locker = &mutex{}
 
+func init() {
+	httpClient = func(context.Context) (*http.Client, error) { return http.DefaultClient, nil }
+}
+
 func TestLock(t *testing.T) {
 	// google cloud storage stub
 	storage := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +54,6 @@ func TestLock(t *testing.T) {
 	}))
 	defer storage.Close()
 	storageLockURL = storage.URL
-	httpClient = func(context.Context) (*http.Client, error) { return http.DefaultClient, nil }
 	m, err := New(nil, "stub", "gcslock", "lock")
 	if err != nil {
 		t.Fatal(err)

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -15,7 +15,6 @@
 package gcslock
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"


### PR DESCRIPTION
along with some other cleanup (fixed stubbing of oauth in tests,
improved error reporting in tests).